### PR TITLE
Fix race issue with health package

### DIFF
--- a/health_test.go
+++ b/health_test.go
@@ -75,6 +75,16 @@ func TestRegisterDependency(t *testing.T) {
 	}
 }
 
+func TestInitialiseServiceCheck(t *testing.T) {
+	check, err := InitialiseServiceCheck("", 50*time.Millisecond)
+	if err == nil {
+		t.Errorf("expecting %v got %v", ErrNoServiceNameSupplied, err)
+	}
+	if check != nil {
+		t.Errorf("expected nil got %v", check)
+	}
+}
+
 func TestDependency(t *testing.T) {
 	tests := []struct {
 		dependency  *Dependency


### PR DESCRIPTION
Issue: Running go test with the -race flag returns an error.

Updating functions to use a mutex to avoid reading and writing to the same location.