### PR TITLE
Feature/split start check

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ check.RegisterDependency("google", health.LevelHard, func() bool {
 })
 ```
 
+#### Start the check
+```go
+check.StartCheck()
+```
+
 #### Serve the healthchecks
 ```go
 router.Handle("/health", health.HTTPHandler)

--- a/health.go
+++ b/health.go
@@ -192,7 +192,7 @@ func (s *ServiceCheck) WriteStatus(w io.Writer) error {
 
 // HTTPHandler outputs the status with the relevant response code to a ResponseWriter
 func (s *ServiceCheck) HTTPHandler(w http.ResponseWriter, r *http.Request) {
-	if s.Healthy {
+	if s.getHealth() {
 		w.WriteHeader(200)
 	} else {
 		w.WriteHeader(503)
@@ -203,7 +203,7 @@ func (s *ServiceCheck) HTTPHandler(w http.ResponseWriter, r *http.Request) {
 
 // IsHealthy returns a bool whether this ServiceCheck is healthy
 func (s *ServiceCheck) IsHealthy() bool {
-	return s.Healthy
+	return s.getHealth()
 }
 
 // Get is a wrapper which checks whether the URL is healthy

--- a/health.go
+++ b/health.go
@@ -79,7 +79,7 @@ func Check200Helper(rawURL string) (bool, error) {
 // It's dependencies will be polled every `duration`.
 //
 // Since v2.0.0 the user is required to start the check themselves by calling
-// StartCheck once all dependancies are registered
+// StartCheck once all dependencies are registered
 func InitialiseServiceCheck(name string, duration time.Duration) (*ServiceCheck, error) {
 	if name == "" {
 		return nil, ErrNoServiceNameSupplied

--- a/health.go
+++ b/health.go
@@ -11,10 +11,6 @@ import (
 	"time"
 )
 
-var (
-	mutex sync.RWMutex
-)
-
 // Level is used to outline an acceptable level of dependency failure
 type Level uint32
 
@@ -43,6 +39,7 @@ type ServiceCheck struct {
 	Dependencies []*Dependency `json:"dependencies"`
 
 	duration time.Duration
+	mu       sync.RWMutex
 }
 
 // Dependency defines a dependency and it's status
@@ -80,6 +77,9 @@ func Check200Helper(rawURL string) (bool, error) {
 
 // InitialiseServiceCheck returns an initialised check for the service `name`.
 // It's dependencies will be polled every `duration`.
+//
+// Since v2.0.0 the user is required to start the check themselves by calling
+// StartCheck once all dependancies are registered
 func InitialiseServiceCheck(name string, duration time.Duration) (*ServiceCheck, error) {
 	if name == "" {
 		return nil, ErrNoServiceNameSupplied
@@ -89,8 +89,6 @@ func InitialiseServiceCheck(name string, duration time.Duration) (*ServiceCheck,
 		Name:     name,
 		duration: duration,
 	}
-
-	check.startCheck()
 
 	return check, nil
 }
@@ -114,14 +112,8 @@ func (s *ServiceCheck) WaitForDependencies(timeout time.Duration) bool {
 	return s.getHealth()
 }
 
-// getHealth is a helper function to make sure a mutex is taken when reading this value
-func (s *ServiceCheck) getHealth() bool {
-	mutex.RLock()
-	defer mutex.RUnlock()
-	return s.Healthy
-}
-
-func (s *ServiceCheck) startCheck() {
+// StartCheck will start checking the dependencies
+func (s *ServiceCheck) StartCheck() {
 	go func() {
 		for {
 			s.updateStatus()
@@ -152,16 +144,16 @@ func (s *ServiceCheck) RegisterDependency(name string, level Level, check func()
 		check: check,
 	}
 
-	mutex.Lock()
+	s.mu.Lock()
 	s.Dependencies = append(s.Dependencies, dep)
-	mutex.Unlock()
+	s.mu.Unlock()
 	return nil
 }
 
 // Dependency finds and returns the named dependency
 func (s *ServiceCheck) Dependency(name string) (*Dependency, error) {
-	mutex.RLock()
-	defer mutex.RUnlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	for _, dependency := range s.Dependencies {
 		if dependency.Name == name {
 			return dependency, nil
@@ -171,9 +163,15 @@ func (s *ServiceCheck) Dependency(name string) (*Dependency, error) {
 	return nil, ErrNoDependency
 }
 
+func (s *ServiceCheck) getHealth() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.Healthy
+}
+
 func (s *ServiceCheck) updateStatus() {
-	mutex.Lock()
-	defer mutex.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	// loop through and change to unhealthy if any dependents are unhealthy
 	for _, dependency := range s.Dependencies {
 		dependency.Healthy = dependency.check()
@@ -194,7 +192,7 @@ func (s *ServiceCheck) WriteStatus(w io.Writer) error {
 
 // HTTPHandler outputs the status with the relevant response code to a ResponseWriter
 func (s *ServiceCheck) HTTPHandler(w http.ResponseWriter, r *http.Request) {
-	if s.getHealth() {
+	if s.Healthy {
 		w.WriteHeader(200)
 	} else {
 		w.WriteHeader(503)
@@ -205,7 +203,7 @@ func (s *ServiceCheck) HTTPHandler(w http.ResponseWriter, r *http.Request) {
 
 // IsHealthy returns a bool whether this ServiceCheck is healthy
 func (s *ServiceCheck) IsHealthy() bool {
-	return s.getHealth()
+	return s.Healthy
 }
 
 // Get is a wrapper which checks whether the URL is healthy
@@ -233,7 +231,7 @@ func Get(url string) (bool, error) {
 		return false, err
 	}
 
-	return response.getHealth(), nil
+	return response.Healthy, nil
 }
 
 // Errors

--- a/health_test.go
+++ b/health_test.go
@@ -260,3 +260,16 @@ func TestWaitForDependencies(t *testing.T) {
 		}
 	})
 }
+
+func TestGetHealth(t *testing.T) {
+	healthCheck := &ServiceCheck{
+		Name:     "test",
+		Healthy:  true,
+		duration: 0,
+	}
+
+	healthy := healthCheck.Healthy
+	if !healthy {
+		t.Error("expected to be healthy")
+	}
+}


### PR DESCRIPTION
For the last few days I've been trying to debug some race issues that have been happening.

Adam added some mutexes to the package in order to pass the `-race` tests in go. When importing this update into bookie, it was causing contention and unpredictable behaviour. This in effect was stopping bookie from running because the mutexes were locking when initialising.

We (maybe it was @domudall) noticed that we start checking the updates before any dependencies are registered and this is likely to be where problems were occurring.

The changes I've made are to essentially move the looping goroutine out of the initialise function, and the service that sets it up will need to call manually after registering dependencies.

This of course is a *breaking change*