### PR TITLE
Adding support for passing a custom httpClient

### DIFF
--- a/health.go
+++ b/health.go
@@ -54,8 +54,8 @@ type Dependency struct {
 // Check200Helper is a helper for checking a service's health endpoint.
 // Function supports passing an optional *http.Client to use a different
 // timeout for the health check.
-func Check200Helper(rawURL string, clients ...*http.Client) (bool, error) {
-	client := getHTTPClient(clients)
+func Check200Helper(rawURL string, optionalClient ...*http.Client) (bool, error) {
+	client := getHTTPClient(optionalClient)
 
 	u, err := url.ParseRequestURI(rawURL)
 	if err != nil {
@@ -211,11 +211,11 @@ func (s *ServiceCheck) IsHealthy() bool {
 }
 
 // Get is a wrapper which checks whether the URL is healthy
-func Get(url string, clients ...*http.Client) (bool, error) {
+func Get(url string, optionalClient ...*http.Client) (bool, error) {
 	var (
 		response ServiceCheck
 	)
-	client := getHTTPClient(clients)
+	client := getHTTPClient(optionalClient)
 	r, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return false, err
@@ -240,9 +240,9 @@ func Get(url string, clients ...*http.Client) (bool, error) {
 
 // getHTTPClient is a helper function to parse the optional argument
 // and either return the passed HTTP client or use the default HTTPClient
-func getHTTPClient(clients []*http.Client) *http.Client {
-	if len(clients) > 0 {
-		return clients[0]
+func getHTTPClient(optionalClient []*http.Client) *http.Client {
+	if len(optionalClient) > 0 {
+		return optionalClient[0]
 	}
 	return HTTPClient
 }

--- a/health.go
+++ b/health.go
@@ -45,7 +45,8 @@ type Dependency struct {
 	Name    string `json:"name"`
 	Healthy bool   `json:"healthy"`
 	Level   Level  `json:"level"`
-	check   func() bool
+
+	check func() bool
 }
 
 // InitialiseServiceCheck returns an initialised check for the service `name`.

--- a/health.go
+++ b/health.go
@@ -54,9 +54,6 @@ type Dependency struct {
 //
 // Since v2.0.0 the user is required to start the check themselves by calling
 // StartCheck once all dependencies are registered
-//
-// Since v3.0.0 the user is required to specify the time duration of the health checks
-// This is to allow control of how frequently the health checks are made
 func InitialiseServiceCheck(name string, duration time.Duration) (*ServiceCheck, error) {
 	if name == "" {
 		return nil, ErrNoServiceNameSupplied

--- a/health.go
+++ b/health.go
@@ -35,8 +35,9 @@ type ServiceCheck struct {
 	Name         string        `json:"name"`
 	Healthy      bool          `json:"healthy"`
 	Dependencies []*Dependency `json:"dependencies"`
-	duration     time.Duration
-	mu           sync.RWMutex
+
+	duration time.Duration
+	mu       sync.RWMutex
 }
 
 // Dependency defines a dependency and it's status

--- a/health_test.go
+++ b/health_test.go
@@ -154,7 +154,7 @@ func TestEndpointHelper(t *testing.T) {
 			t.Errorf("expected %v got %v", test.expected, resp)
 		}
 
-		resp, err = Check200HelperCustomHTTPClient(server.URL, testHTTPClient)
+		resp, err = Check200Helper(server.URL, testHTTPClient)
 		if err != test.expectedErr {
 			t.Errorf("expected %v got %v", test.expectedErr, err)
 		}
@@ -196,6 +196,12 @@ func TestHTTPHandler(t *testing.T) {
 }
 
 func TestGet(t *testing.T) {
+	var (
+		testHTTPClient = &http.Client{
+			Timeout:   1 * time.Second,
+			Transport: http.DefaultTransport,
+		}
+	)
 	tests := []struct {
 		healthy  bool
 		expected bool
@@ -220,34 +226,8 @@ func TestGet(t *testing.T) {
 		if healthy != test.expected {
 			t.Errorf("expected %v, got %v", test.expected, healthy)
 		}
-	}
-}
 
-func TestGetCustomHTTPClient(t *testing.T) {
-	var (
-		testHTTPClient = &http.Client{
-			Timeout:   1 * time.Second,
-			Transport: http.DefaultTransport,
-		}
-	)
-
-	tests := []struct {
-		healthy  bool
-		expected bool
-	}{
-		{true, true},
-		{false, false},
-	}
-
-	for _, test := range tests {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			json.NewEncoder(w).Encode(&ServiceCheck{
-				Name:    "test",
-				Healthy: test.healthy,
-			})
-		}))
-
-		healthy, err := GetCustomHTTPClient(server.URL, testHTTPClient)
+		healthy, err = Get(server.URL, testHTTPClient)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}


### PR DESCRIPTION
Issue in the Get and Check200Helper a hardcoded timeout of 5ms is used.

Not all services may be able to support the health URL being request as frequently.

To fix this issue I have updated Get and Check200Helper to pass an optional http.Client in the checks. If this is not passed it will use the existing HTTPClient function.