### PR TITLE
Adding the defer resp.Body before the status code check

### DIFF
--- a/health.go
+++ b/health.go
@@ -72,6 +72,9 @@ func Check200Helper(rawURL string, optionalClient ...*http.Client) (bool, error)
 		return false, err
 	}
 
+	// ensure resp.Body is closed when function returns
+	defer resp.Body.Close()
+
 	if resp.StatusCode != http.StatusOK {
 		return false, nil
 	}
@@ -226,11 +229,13 @@ func Get(url string, optionalClient ...*http.Client) (bool, error) {
 		return false, err
 	}
 
+	// ensure resp.Body is closed when function returns
+	defer resp.Body.Close()
+
 	if resp.StatusCode != http.StatusOK {
 		return false, nil
 	}
 
-	defer resp.Body.Close()
 	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Issue:
Seems to be a small memory leak with the health package if the Get request gets called to frequently.

Fix: Ensuring` defer resp.Body.Close()` is called when the `Do.Client` request doesn't return an error.

Added benchmarking of the functions for comparison using the go tool:
`go test -bench=. -benchmem`

Previous version of Get and Check200Helper
```
BenchmarkGet-4              	   3000	   677425 ns/op	  34977 B/op	    317 allocs/op
BenchmarkCheck200Helper-4      1000	  1205606 ns/op	  36538 B/op	    286 allocs/op
PASS
ok  	github.com/fresh8/health	5.510s
```
Following changes:
```
BenchmarkGet-4              	   3000	   563503 ns/op	  30306 B/op	    309 allocs/op
BenchmarkCheck200Helper-4      1000	  1046441 ns/op	  35432 B/op	    285 allocs/op
PASS
ok  	github.com/fresh8/health	4.982s
```
